### PR TITLE
fix: remove llm_output relay, use sentinel_act as sole delivery

### DIFF
--- a/.changeset/remove-llm-output-relay.md
+++ b/.changeset/remove-llm-output-relay.md
@@ -1,0 +1,5 @@
+---
+"@coffeexdev/openclaw-sentinel": patch
+---
+
+Remove llm_output relay; use sentinel_act as sole delivery mechanism. The LLM now delivers results exclusively via sentinel_act notify, eliminating double-delivery of internal reasoning text. Timeout fallback remains as safety net.

--- a/README.md
+++ b/README.md
@@ -372,9 +372,9 @@ Precedence: **watcher override > global setting**.
 
 1. Callback is enqueued to isolated hook session.
 2. Contract captures original delivery context (`deliveryContext` + resolved `deliveryTargets`).
-3. First assistant-authored `llm_output` for that pending callback is relayed to target chat.
-4. Reserved control outputs are never relayed (`NO_REPLY`, `HEARTBEAT_OK`, empty variants). If output is unusable, Sentinel sends a concise contextual guardrail fallback.
-5. If no assistant output arrives in time (`hookResponseTimeoutMs`), timeout fallback is configurable:
+3. The LLM calls `sentinel_act notify` to deliver results to targets (sole delivery mechanism).
+4. Any successful `sentinel_act` call fulfills the relay contract and cancels the timeout timer.
+5. If no `sentinel_act` call arrives in time (`hookResponseTimeoutMs`), timeout fallback is configurable:
    - `hookResponseFallbackMode: "concise"` (default) sends a short fail-safe relay.
    - `hookResponseFallbackMode: "none"` suppresses timeout fallback.
 6. Repeated callbacks with same dedupe key are idempotent within `hookResponseDedupeWindowMs`.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -57,8 +57,8 @@ Move the config to `plugins.entries.openclaw-sentinel.config`.
 - Preferred shape is a callback envelope (`type: "sentinel.callback"`).
 - Sentinel prepends structured instructions for the agent to use watcher + payload context, apply policy, act safely, and return a user-facing response.
 - Callback processing is isolated by watcher session by default (`...:watcher:<id>`), with optional explicit grouping via `hookSessionGroup`.
-- Hook callbacks establish a response-delivery contract: assistant `llm_output` is relayed to original targets.
-- Reserved control outputs are suppressed (`NO_REPLY`, `HEARTBEAT_OK`, empty variants). If model output is unusable, Sentinel emits a concise contextual fallback.
+- Hook callbacks establish a response-delivery contract: `sentinel_act notify` is the sole delivery mechanism.
+- If the LLM fails to call `sentinel_act` before the timeout, Sentinel sends a concise contextual fallback.
   Example structured wake event text:
 
 ```text
@@ -67,9 +67,10 @@ SENTINEL_TRIGGER: A sentinel watcher callback has fired. Analyze the callback an
 Instructions:
 - Review the watcher intent, event payload, and operator goal (if present).
 - Use sentinel_act to execute remediation actions when the situation calls for it.
+- Use sentinel_act with action "notify" to send the result to delivery targets. This is the only way your response reaches the user.
 - Use sentinel_escalate if the situation requires user attention or is beyond your ability to resolve.
-- After any actions, provide a concise user-facing summary of what happened and what was done.
-- Never emit control tokens such as NO_REPLY or HEARTBEAT_OK.
+- If escalating, also use sentinel_act notify to inform delivery targets of the escalation.
+- Do not emit control tokens, routing directives, or internal processing notes in your text output.
 
 SENTINEL_CALLBACK_JSON:
 {
@@ -235,7 +236,7 @@ For `/hooks/sentinel`, Sentinel tracks callback-triggered response contracts sep
 
 Config knobs:
 
-- `hookResponseTimeoutMs` — wait window for assistant-authored `llm_output` relay (default `30000`).
+- `hookResponseTimeoutMs` — wait window for `sentinel_act` call before timeout fallback (default `30000`).
 - `hookResponseFallbackMode` — timeout behavior: `concise` (default fail-safe relay) or `none`.
 - `hookResponseDedupeWindowMs` — dedupe/idempotency window for repeated callback dedupe keys.
 
@@ -243,9 +244,9 @@ Flow:
 
 1. Callback is enqueued to isolated hook session.
 2. Contract stores original delivery context (`deliveryTargets` and/or `deliveryContext`).
-3. First assistant-authored output is relayed to original chat target(s).
-4. Reserved control outputs (`NO_REPLY`, `HEARTBEAT_OK`, empty variants) are suppressed. If output is unusable, Sentinel sends concise contextual guardrail fallback text.
-5. If no assistant output arrives by timeout, optional concise timeout fallback relay is sent.
+3. The LLM calls `sentinel_act notify` to deliver results to targets (sole delivery mechanism).
+4. Any successful `sentinel_act` call fulfills the relay contract and cancels the timeout timer.
+5. If no `sentinel_act` call arrives by timeout, optional concise timeout fallback relay is sent.
 6. Duplicate callbacks with same dedupe key inside dedupe window are ignored for extra relay contracts.
 
 ---

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,6 @@ const MAX_SENTINEL_WEBHOOK_TEXT_CHARS = 8000;
 const MAX_SENTINEL_PAYLOAD_JSON_CHARS = 2500;
 const SENTINEL_CALLBACK_WAKE_REASON = "cron:sentinel-callback";
 const SENTINEL_CALLBACK_CONTEXT_KEY = "cron:sentinel-callback";
-const RESERVED_CONTROL_TOKEN_PATTERN = /\b(?:NO[\s_-]*REPLY|HEARTBEAT[\s_-]*OK)\b/gi;
 
 const SUPPORTED_DELIVERY_CHANNELS = new Set([
   "telegram",
@@ -182,9 +181,10 @@ function buildCallbackPrompt(envelope: SentinelCallbackEnvelope): string {
     "Instructions:",
     "- Review the watcher intent, event payload, and operator goal (if present).",
     "- Use sentinel_act to execute remediation actions when the situation calls for it.",
+    '- Use sentinel_act with action "notify" to send the result to delivery targets. This is the only way your response reaches the user.',
     "- Use sentinel_escalate if the situation requires user attention or is beyond your ability to resolve.",
-    "- After any actions, provide a concise user-facing summary of what happened and what was done.",
-    "- Never emit control tokens such as NO_REPLY or HEARTBEAT_OK.",
+    "- If escalating, also use sentinel_act notify to inform delivery targets of the escalation.",
+    "- Do not emit control tokens, routing directives, or internal processing notes in your text output.",
     "",
     "SENTINEL_CALLBACK_JSON:",
     JSON.stringify(callbackJson, null, 2),
@@ -204,30 +204,6 @@ function normalizeDeliveryTargets(targets: DeliveryTarget[]): DeliveryTarget[] {
     deduped.set(key, { channel, to, ...(accountId ? { accountId } : {}) });
   }
   return [...deduped.values()];
-}
-
-function normalizeControlTokenCandidate(value: string): string {
-  return value.replace(/[^a-zA-Z]/g, "").toUpperCase();
-}
-
-function sanitizeAssistantRelaySegment(value: string): string {
-  if (typeof value !== "string") return "";
-
-  const tokenCandidate = normalizeControlTokenCandidate(value.trim());
-  if (tokenCandidate === "NOREPLY" || tokenCandidate === "HEARTBEATOK") return "";
-
-  const withoutTokens = value.replace(RESERVED_CONTROL_TOKEN_PATTERN, " ").trim();
-  if (!withoutTokens) return "";
-
-  const collapsed = withoutTokens.replace(/\s+/g, " ").trim();
-  return /[a-zA-Z0-9]/.test(collapsed) ? collapsed : "";
-}
-
-function normalizeAssistantRelayText(assistantTexts: string[]): string | undefined {
-  if (!Array.isArray(assistantTexts) || assistantTexts.length === 0) return undefined;
-  const parts = assistantTexts.map(sanitizeAssistantRelaySegment).filter(Boolean);
-  if (parts.length === 0) return undefined;
-  return trimText(parts.join("\n\n"), MAX_SENTINEL_WEBHOOK_TEXT_CHARS);
 }
 
 function resolveHookResponseDedupeWindowMs(config: SentinelConfig): number {
@@ -490,23 +466,16 @@ class HookResponseRelayManager {
     };
   }
 
-  async handleLlmOutput(sessionKey: string | undefined, assistantTexts: string[]): Promise<void> {
+  fulfill(sessionKey: string | undefined): void {
     if (!sessionKey) return;
-    if (!Array.isArray(assistantTexts) || assistantTexts.length === 0) return;
-
     const dedupeKey = this.popNextPendingDedupe(sessionKey);
     if (!dedupeKey) return;
-
     const pending = this.pendingByDedupe.get(dedupeKey);
     if (!pending || pending.state !== "pending") return;
-
-    const assistantMessage = normalizeAssistantRelayText(assistantTexts);
-    if (assistantMessage) {
-      await this.completeWithMessage(pending, assistantMessage, "assistant");
-      return;
-    }
-
-    await this.completeWithMessage(pending, pending.fallbackMessage, "guardrail");
+    this.markClosed(pending, "completed");
+    this.api.logger?.info?.(
+      `[openclaw-sentinel] Relay contract fulfilled via sentinel_act for dedupe=${dedupeKey}`,
+    );
   }
 
   dispose(): void {
@@ -606,27 +575,16 @@ class HookResponseRelayManager {
       return;
     }
 
-    await this.completeWithMessage(pending, pending.fallbackMessage, "timeout");
+    await this.completeWithMessage(pending, pending.fallbackMessage);
   }
 
-  private async completeWithMessage(
-    pending: PendingHookResponse,
-    message: string,
-    source: "assistant" | "timeout" | "guardrail",
-  ): Promise<void> {
+  private async completeWithMessage(pending: PendingHookResponse, message: string): Promise<void> {
     const delivery = await deliverMessageToTargets(this.api, pending.relayTargets, message);
 
-    this.markClosed(pending, source === "assistant" ? "completed" : "timed_out");
-
-    const action =
-      source === "assistant"
-        ? "Relayed assistant response"
-        : source === "guardrail"
-          ? "Sent guardrail fallback"
-          : "Sent timeout fallback";
+    this.markClosed(pending, "timed_out");
 
     this.api.logger?.info?.(
-      `[openclaw-sentinel] ${action} for dedupe=${pending.dedupeKey} delivered=${delivery.delivered} failed=${delivery.failed}`,
+      `[openclaw-sentinel] Sent timeout fallback for dedupe=${pending.dedupeKey} delivered=${delivery.delivered} failed=${delivery.failed}`,
     );
   }
 
@@ -748,6 +706,8 @@ export function createSentinelPlugin(overrides?: Partial<SentinelConfig>) {
       registerSentinelControl(api.registerTool.bind(api), manager);
       registerSentinelActionTools(api.registerTool.bind(api), manager, api, config);
 
+      let hookResponseRelayManager: HookResponseRelayManager | undefined;
+
       if (typeof api.on === "function") {
         api.on("before_tool_call", (event, ctx) => {
           if (!isSentinelSession(ctx.sessionKey, config)) return;
@@ -762,6 +722,10 @@ export function createSentinelPlugin(overrides?: Partial<SentinelConfig>) {
 
         api.on("after_tool_call", (event, ctx) => {
           if (!isSentinelSession(ctx.sessionKey, config)) return;
+
+          if (event.toolName === "sentinel_act" && !event.error) {
+            hookResponseRelayManager?.fulfill(ctx.sessionKey);
+          }
 
           api.logger?.info?.(
             `[openclaw-sentinel] Action trace: tool=${event.toolName} duration=${event.durationMs}ms error=${event.error ?? "none"}`,
@@ -787,12 +751,7 @@ export function createSentinelPlugin(overrides?: Partial<SentinelConfig>) {
         return;
       }
 
-      const hookResponseRelayManager = new HookResponseRelayManager(config, api);
-      if (typeof api.on === "function") {
-        api.on("llm_output", (event, ctx) => {
-          void hookResponseRelayManager.handleLlmOutput(ctx?.sessionKey, event.assistantTexts);
-        });
-      }
+      hookResponseRelayManager = new HookResponseRelayManager(config, api);
 
       try {
         api.registerHttpRoute({

--- a/tests/sentinel-callback-e2e.test.ts
+++ b/tests/sentinel-callback-e2e.test.ts
@@ -511,13 +511,12 @@ describe("sentinel runtime callback e2e", () => {
     expect(payloadText).toContain("deliveryTargets");
     expect(payloadText).toContain("currentPrice");
 
+    // Mock model does not call sentinel_act, so timeout fallback should fire
     await waitFor(
-      "assistant relay completion",
+      "timeout fallback relay",
       () => {
         const line = gatewayLogs.find((entry) =>
-          entry.includes(
-            `Relayed assistant response for dedupe=${callbackResponse.relay.dedupeKey}`,
-          ),
+          entry.includes(`Sent timeout fallback for dedupe=${callbackResponse.relay.dedupeKey}`),
         );
         return line;
       },
@@ -526,7 +525,7 @@ describe("sentinel runtime callback e2e", () => {
     );
   }, 120_000);
 
-  it("suppresses control tokens and uses guardrail relay fallback in live runtime", async () => {
+  it("fires timeout fallback when LLM does not call sentinel_act in live runtime", async () => {
     const modelServer = requireModelServer();
     const initialCount = modelServer.requests.length;
     modelServer.enqueueAssistantText("NO_REPLY");
@@ -544,7 +543,7 @@ describe("sentinel runtime callback e2e", () => {
     expect(callbackResponse.relay.pending).toBe(true);
 
     await waitFor(
-      "runtime model request for control-token callback",
+      "runtime model request for callback",
       () => {
         if (modelServer.requests.length <= initialCount) return undefined;
         return modelServer.requests.at(-1);
@@ -553,24 +552,17 @@ describe("sentinel runtime callback e2e", () => {
       100,
     );
 
+    // No sentinel_act called, so timeout fallback fires
     await waitFor(
-      "guardrail fallback relay",
+      "timeout fallback relay",
       () => {
         const line = gatewayLogs.find((entry) =>
-          entry.includes(`Sent guardrail fallback for dedupe=${callbackResponse.relay.dedupeKey}`),
+          entry.includes(`Sent timeout fallback for dedupe=${callbackResponse.relay.dedupeKey}`),
         );
         return line;
       },
       20_000,
       100,
     );
-
-    const sameDedupeLogs = gatewayLogs.filter((entry) =>
-      entry.includes(`dedupe=${callbackResponse.relay.dedupeKey}`),
-    );
-    const relayedAsAssistant = sameDedupeLogs.some((entry) =>
-      entry.includes("Relayed assistant response"),
-    );
-    expect(relayedAsAssistant).toBe(false);
   }, 120_000);
 });

--- a/tests/sentinel-callback-integration.test.ts
+++ b/tests/sentinel-callback-integration.test.ts
@@ -295,7 +295,7 @@ describe("sentinel callback e2e", () => {
     expect(dispatchBody.trigger).toMatchObject({ priority: "critical" });
 
     const relayedPrompt = String(enqueueSystemEvent.mock.calls[0][0] ?? "");
-    expect(relayedPrompt).toContain("Never emit control tokens");
+    expect(relayedPrompt).toContain("Do not emit control tokens");
     expect(relayedPrompt).toContain("incident_triage");
   });
 });

--- a/tests/sentinel-webhook-callback.test.ts
+++ b/tests/sentinel-webhook-callback.test.ts
@@ -233,7 +233,8 @@ describe("sentinel webhook callback route", () => {
     const [text] = mocks.enqueueSystemEvent.mock.calls[0];
     expect(String(text)).toContain("sentinel_act");
     expect(String(text)).toContain("sentinel_escalate");
-    expect(String(text)).toContain("Never emit control tokens");
+    expect(String(text)).toContain("the only way your response reaches the user");
+    expect(String(text)).toContain("Do not emit control tokens");
 
     const callbackJson = extractJsonBlock(String(text), "SENTINEL_CALLBACK_JSON:\n");
 
@@ -377,17 +378,18 @@ describe("sentinel webhook callback route", () => {
     expect(res.statusCode).toBe(200);
   });
 
-  it("relays assistant-authored hook responses back to original chat targets", async () => {
+  it("fulfills relay contract via after_tool_call when sentinel_act succeeds", async () => {
+    vi.useFakeTimers();
     const mocks = createApiMocks();
 
     const plugin = createSentinelPlugin({
       hookResponseTimeoutMs: 60_000,
-      hookResponseFallbackMode: "none",
+      hookResponseFallbackMode: "concise",
     });
     plugin.register(mocks.api);
 
-    const llmOutput = mocks.hooks.get("llm_output");
-    expect(typeof llmOutput).toBe("function");
+    const afterToolCall = mocks.hooks.get("after_tool_call");
+    expect(typeof afterToolCall).toBe("function");
 
     const route = mocks.registerHttpRoute.mock.calls[0][0];
     const req = makeReq(
@@ -419,17 +421,6 @@ describe("sentinel webhook callback route", () => {
 
     await route.handler(req as any, res as any);
 
-    expect(mocks.sendMessageTelegram).toHaveBeenCalledTimes(0);
-
-    await llmOutput?.(
-      { assistantTexts: ["BTC crossed threshold. Consider reducing exposure."] },
-      { sessionKey: "agent:main:hooks:sentinel:watcher:btc-price" },
-    );
-
-    expect(mocks.sendMessageTelegram).toHaveBeenCalledTimes(1);
-    const [, message] = mocks.sendMessageTelegram.mock.calls[0];
-    expect(String(message)).toContain("BTC crossed threshold");
-
     const body = JSON.parse(res.body ?? "{}");
     expect(body.relay).toMatchObject({
       attempted: 1,
@@ -437,120 +428,30 @@ describe("sentinel webhook callback route", () => {
       failed: 0,
       deduped: false,
       pending: true,
-      fallbackMode: "none",
     });
-  });
 
-  it("suppresses reserved control outputs and relays concise guardrail fallback", async () => {
-    const mocks = createApiMocks();
-
-    const plugin = createSentinelPlugin({
-      hookResponseTimeoutMs: 60_000,
-      hookResponseFallbackMode: "none",
-    });
-    plugin.register(mocks.api);
-
-    const llmOutput = mocks.hooks.get("llm_output");
-    const route = mocks.registerHttpRoute.mock.calls[0][0];
-    await route.handler(
-      makeReq(
-        "POST",
-        JSON.stringify(
-          makeEnvelope({
-            watcher: {
-              id: "btc-price",
-              skillId: "skills.alerts",
-              eventName: "price_alert",
-              intent: "price_alert",
-              strategy: "http-poll",
-              endpoint: "https://example.com/btc",
-              match: "all",
-              conditions: [],
-              fireOnce: false,
-              tags: [],
-            },
-            trigger: {
-              matchedAt: new Date().toISOString(),
-              dedupeKey: "hb-guard-1",
-              priority: "normal",
-            },
-            deliveryTargets: [{ channel: "telegram", to: "5613673222" }],
-          }),
-        ),
-      ) as any,
-      makeRes() as any,
-    );
-
-    await llmOutput?.(
-      { assistantTexts: ["   `NO_REPLY`   ", "HEARTBEAT_OK"] },
+    await afterToolCall?.(
+      { toolName: "sentinel_act", durationMs: 50 },
       { sessionKey: "agent:main:hooks:sentinel:watcher:btc-price" },
     );
 
-    expect(mocks.sendMessageTelegram).toHaveBeenCalledTimes(1);
-    const [, fallbackMessage] = mocks.sendMessageTelegram.mock.calls[0];
-    expect(String(fallbackMessage)).toContain("Sentinel callback: price_alert");
-    expect(String(fallbackMessage)).not.toContain("NO_REPLY");
-    expect(String(fallbackMessage)).not.toContain("HEARTBEAT_OK");
+    // Timeout should not fire after fulfill
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.runAllTimersAsync();
+
+    expect(mocks.sendMessageTelegram).toHaveBeenCalledTimes(0);
   });
 
-  it("falls back when assistant output is unusable/empty variants", async () => {
+  it("uses callback deliveryContext as fallback relay target via timeout path", async () => {
+    vi.useFakeTimers();
     const mocks = createApiMocks();
 
     const plugin = createSentinelPlugin({
-      hookResponseTimeoutMs: 60_000,
-      hookResponseFallbackMode: "none",
+      hookResponseTimeoutMs: 1000,
+      hookResponseFallbackMode: "concise",
     });
     plugin.register(mocks.api);
 
-    const llmOutput = mocks.hooks.get("llm_output");
-    const route = mocks.registerHttpRoute.mock.calls[0][0];
-
-    await route.handler(
-      makeReq(
-        "POST",
-        JSON.stringify(
-          makeEnvelope({
-            watcher: {
-              id: "empty-variant",
-              skillId: "skills.ops",
-              eventName: "service_degraded",
-              intent: "service_degraded",
-              strategy: "http-poll",
-              endpoint: "https://example.com",
-              match: "all",
-              conditions: [],
-              fireOnce: false,
-              tags: [],
-            },
-            trigger: {
-              matchedAt: new Date().toISOString(),
-              dedupeKey: "empty-out-1",
-              priority: "normal",
-            },
-            deliveryTargets: [{ channel: "telegram", to: "5613673222" }],
-          }),
-        ),
-      ) as any,
-      makeRes() as any,
-    );
-
-    await llmOutput?.(
-      { assistantTexts: ["  ", "__NO REPLY__"] },
-      { sessionKey: "agent:main:hooks:sentinel:watcher:empty-variant" },
-    );
-
-    expect(mocks.sendMessageTelegram).toHaveBeenCalledTimes(1);
-    const [, fallbackMessage] = mocks.sendMessageTelegram.mock.calls[0];
-    expect(String(fallbackMessage)).toContain("Sentinel callback: service_degraded");
-  });
-
-  it("uses callback deliveryContext as fallback relay target when deliveryTargets are absent", async () => {
-    const mocks = createApiMocks();
-
-    const plugin = createSentinelPlugin({ hookResponseFallbackMode: "none" });
-    plugin.register(mocks.api);
-
-    const llmOutput = mocks.hooks.get("llm_output");
     const route = mocks.registerHttpRoute.mock.calls[0][0];
 
     await route.handler(
@@ -586,10 +487,8 @@ describe("sentinel webhook callback route", () => {
       makeRes() as any,
     );
 
-    await llmOutput?.(
-      { assistantTexts: ["Context-based response routing works."] },
-      { sessionKey: "agent:main:hooks:sentinel:watcher:from-context" },
-    );
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.runAllTimersAsync();
 
     expect(mocks.sendMessageTelegram).toHaveBeenCalledTimes(1);
     const [to] = mocks.sendMessageTelegram.mock.calls[0];
@@ -647,15 +546,17 @@ describe("sentinel webhook callback route", () => {
   });
 
   it("suppresses duplicate response contracts using dedupe key", async () => {
+    vi.useFakeTimers();
     const mocks = createApiMocks();
 
     const plugin = createSentinelPlugin({
       hookResponseDedupeWindowMs: 60_000,
-      hookResponseFallbackMode: "none",
+      hookResponseTimeoutMs: 60_000,
+      hookResponseFallbackMode: "concise",
     });
     plugin.register(mocks.api);
 
-    const llmOutput = mocks.hooks.get("llm_output");
+    const afterToolCall = mocks.hooks.get("after_tool_call");
     const route = mocks.registerHttpRoute.mock.calls[0][0];
 
     const payload = makeEnvelope({
@@ -683,12 +584,16 @@ describe("sentinel webhook callback route", () => {
     const res2 = makeRes();
     await route.handler(makeReq("POST", JSON.stringify(payload)) as any, res2 as any);
 
-    await llmOutput?.(
-      { assistantTexts: ["single response despite duplicate callback"] },
+    await afterToolCall?.(
+      { toolName: "sentinel_act", durationMs: 50 },
       { sessionKey: "agent:main:hooks:sentinel:watcher:btc-price" },
     );
 
-    expect(mocks.sendMessageTelegram).toHaveBeenCalledTimes(1);
+    // Timeout should not fire after fulfill
+    await vi.advanceTimersByTimeAsync(60_000);
+    await vi.runAllTimersAsync();
+
+    expect(mocks.sendMessageTelegram).toHaveBeenCalledTimes(0);
     expect(JSON.parse(res2.body ?? "{}").relay).toMatchObject({
       attempted: 1,
       deduped: true,


### PR DESCRIPTION
## Summary

- Remove `llm_output` relay hook — it was the pre-v0.8.0 delivery path that caused double-delivery and leaked internal reasoning text (e.g. `[[reply_to_current]]`)
- Add `fulfill()` method to `HookResponseRelayManager`, called via `after_tool_call` when `sentinel_act` succeeds — cancels the timeout timer
- Remove 4 sanitization functions (`RESERVED_CONTROL_TOKEN_PATTERN`, `normalizeControlTokenCandidate`, `sanitizeAssistantRelaySegment`, `normalizeAssistantRelayText`) that only served the removed relay
- Update callback prompt to instruct LLM that `sentinel_act notify` is the only way responses reach users
- Keep timeout fallback as safety net when LLM fails to call `sentinel_act`

Net: ~138 lines removed, ~70 added.

## Test plan

- [x] `pnpm run lint` — type-check passes
- [x] `pnpm run test:unit` — 111 tests pass
- [x] `pnpm run test:e2e` — 2 tests pass
- [x] No `llm_output` references remain in `src/` or `tests/`
- [x] `after_tool_call` for `sentinel_act` fulfills relay contract (timer cancelled)
- [x] Timeout fallback still fires when LLM doesn't call `sentinel_act`
- [x] Dedupe still works via relay manager contract tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)